### PR TITLE
Fix code example for simulating device:fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Here's how an author might use this API to simulate `position: device-fixed`, wh
         // Since the bar is position: fixed we need to offset it by the visual
         // viewport's offset from the layout viewport origin.
         var offsetX = viewport.scrollLeft;
-        var offsetY = document.documentElement.clientHeight
-                    - viewport.clientHeight
+        var offsetY = viewport.clientHeight
+                    - document.documentElement.clientHeight
                     + viewport.scrollTop;
 
         // You could also do this by setting style.left and style.top if you


### PR DESCRIPTION
If I'm understanding the API correctly, the visual viewport's clientHeight will always be less than or equal to the layout viewport's clientHeight. So if we want to implement device:fixed, the y-transform on the item must always be less than or equal to zero, so the code has the clientHeight difference backwards.